### PR TITLE
[ci] Add auto-publish for crates

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,31 @@
+name: Publish on crates.io
+on: 
+  release:
+    types: [created]
+
+jobs:
+  publish:
+    name: Publish
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@master
+    - name: Install Rust
+      uses: actions-rs/toolchain@v1
+      with:
+          toolchain: stable
+          profile: minimal
+          override: true
+    - name: Cargo login
+      uses: actions-rs/cargo@v1
+      with:
+        command: login
+        args: -- ${{ secrets.CARGO_TOKEN }}
+    - name: Publish relations_procmacro
+      uses: actions-rs/cargo@v1
+      with:
+        command: publish
+        args: --manifest-path relations_procmacro/Cargo.toml
+    - name: Publish relations
+      uses: actions-rs/cargo@v1
+      with:
+        command: publish


### PR DESCRIPTION
This should sequentially release `relations_procmacro` then `relations` (they need to be release in this order since `relations` depends on `relations_procmacro`).